### PR TITLE
Patches required to get DiscoServer running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ For running the server code from source, install the following modules:
 * Numpy
 * Pillow or PIL
 
+You can install these from pip by running `pip install -r requirements.txt`.
+
 To run the beat code from source, you will also need to install the following:
 * PyAudio (Google for it and you'll find installers for Windows/Mac/Linux)
 
@@ -82,4 +84,8 @@ Unfortunately, if your pattern throws an error, it's really really hard to detec
 ## Modifying the Web Interface
 The web UI is built using Coffeescript, Backbone, SASS, and Handlebars.  All of these are pretty easy to get a handle on.  The code is built using Grunt, which you should also read up on before diving in.  Finally, the Grunt commands rely on some node modules, so before you begin, go into the `contrl_interface` directory and type `npm install`.  If you don't have node, install it.  You may also need the `grunt-cli` package globally installed from npm (`npm install -g grunt-cli`).
 
+To compile for the first time, use `grunt coffee handlebars sass`.
+
 Before you begin working, the `grunt watch` command will make Grunt recompile your stuff as it changes, which is very useful even though it occasionally fails with Coffeescript.
+
+By default, the UI runs locally on port 90 at http://localhost:90/

--- a/control_interface/.gitignore
+++ b/control_interface/.gitignore
@@ -1,4 +1,5 @@
-js/
+js/*
+!js/init.js
 css/
 .sass-cache
 node_modules

--- a/control_interface/js/init.js
+++ b/control_interface/js/init.js
@@ -1,0 +1,2 @@
+com = {}
+com.firsteast = {}

--- a/control_interface/package.json
+++ b/control_interface/package.json
@@ -6,7 +6,7 @@
     "grunt": "~0.4.1",
     "grunt-contrib-watch": "~0.4.0",
     "grunt-contrib-coffee": "latest",
-    "grunt-contrib-handlebars": "latest",
+    "grunt-contrib-handlebars": "0.8.0",
     "grunt-contrib-sass": "latest",
     "matchdep": "~0.1.1"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Pillow==2.7.0
+Twisted-Core==14.0.2
+Twisted-Web==14.0.2
+Twisted==13.2.0
+autobahn==0.10.4
+numpy==1.8.2
+tornado==4.1


### PR DESCRIPTION
Hey 1e, I wanted to check out what your software looks like and was able to sort of get it running but I had to make a few tweaks so I figured I'd push them to you guys if it's helpful.

---

There were a few missing files & version issues I needed to resolve before  DiscoServer.py would run (and the UI would work).
- `control_interface/js/init.js` was missing
- The version of Handlebars specified by `control_interface/package.json` was `latest`. Handlebars is absolutely terrible at being backwards compatible..

I also set up a `requirements.txt` file for pip (based on what I have installed on my system). And updated `README.md` with some extra bits I wanted to know while setting it up.

---

After these, I was able to run `DiscoServer.py` and access the web UI and it seemed to work! Wooo! But some patterns still cause it to crash with a stack trace that ends in:

```
  File "/home/zbanks/1e-Disco/server/sockets/control.py", line 54, in onMessage
    self.sendRenderMessage(binary)
  File "/home/zbanks/1e-Disco/server/sockets/control.py", line 161, in sendRenderMessage
    'renderData': self.getRenderFrames(),
  File "/home/zbanks/1e-Disco/server/sockets/control.py", line 122, in getRenderFrames
    traceback.print_stack()
images do not match
```

This seemed harder to debug without digging in so I gave up...
